### PR TITLE
Add support for multiple labels

### DIFF
--- a/core/src/main/java/org/neo4j/graphalgo/api/ArrayGraphInterface.java
+++ b/core/src/main/java/org/neo4j/graphalgo/api/ArrayGraphInterface.java
@@ -1,7 +1,5 @@
 package org.neo4j.graphalgo.api;
 
-import scala.Int;
-
 import java.util.Collection;
 import java.util.HashMap;
 
@@ -14,6 +12,8 @@ public interface ArrayGraphInterface {
     int[] getIncomingNodes(int nodeId);
 
     int getLabel(int nodeId);
+
+    Integer[] getLabels(int nodeId);
 
     int getEdgeLabel(long nodeId1, long nodeId2);
 

--- a/core/src/main/java/org/neo4j/graphalgo/api/GraphFactory.java
+++ b/core/src/main/java/org/neo4j/graphalgo/api/GraphFactory.java
@@ -82,7 +82,7 @@ public abstract class GraphFactory {
         return nodeImporter.call();
     }
 
-    protected AbstractMap.SimpleEntry<HashMap<Integer, ArrayList<Object>>, HashMap<AbstractMap.SimpleEntry<Long, Long>, Integer>> loadLabelMap(IdMap mapping, boolean loadLabels) throws EntityNotFoundException {
+    protected AbstractMap.SimpleEntry<HashMap<Integer, ArrayList<LabelImporter.IdNameTuple>>, HashMap<AbstractMap.SimpleEntry<Long, Long>, Integer>> loadLabelMap(IdMap mapping, boolean loadLabels) throws EntityNotFoundException {
         if (!loadLabels){
             return null;
         }

--- a/core/src/main/java/org/neo4j/graphalgo/core/GraphLoader.java
+++ b/core/src/main/java/org/neo4j/graphalgo/core/GraphLoader.java
@@ -194,10 +194,26 @@ public class GraphLoader {
         return this;
     }
 
+    /**
+     * Toggle instruct the loader to load the label names as a property.
+     *
+     * @param loadWithLabels When true label names are loaded, when false they are not.
+     * @return itself to enable fluent interface
+     */
     public GraphLoader withLabelAsProperty(boolean loadWithLabels) {
         this.loadWithLabels = loadWithLabels;
         return this;
     }
+
+    /**
+     * Instructs the loader to load the label names as a property.
+     *
+     * @return itself to enable fluent interface
+     */
+    public GraphLoader withLabelAsProperty() {
+        return withLabelAsProperty(true);
+    }
+
     /**
      * Instructs the loader to load only nodes with the given label name.
      * If the label is not found, every node will be loaded.

--- a/core/src/main/java/org/neo4j/graphalgo/core/heavyweight/HeavyGraphFactory.java
+++ b/core/src/main/java/org/neo4j/graphalgo/core/heavyweight/HeavyGraphFactory.java
@@ -24,10 +24,7 @@ import org.neo4j.graphalgo.api.GraphSetup;
 import org.neo4j.graphalgo.api.WeightMapping;
 import org.neo4j.graphalgo.core.IdMap;
 import org.neo4j.graphalgo.core.LabelImporter;
-import org.neo4j.graphalgo.core.NodeImporter;
 import org.neo4j.graphalgo.core.utils.ParallelUtil;
-import org.neo4j.graphdb.Label;
-import org.neo4j.graphdb.ResourceIterable;
 import org.neo4j.helpers.Exceptions;
 import org.neo4j.kernel.api.exceptions.EntityNotFoundException;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
@@ -67,7 +64,7 @@ public class HeavyGraphFactory extends GraphFactory {
 
         final IdMap idMap = loadIdMap();
 
-        final AbstractMap.SimpleEntry<HashMap<Integer, ArrayList<Object>>, HashMap<AbstractMap.SimpleEntry<Long, Long>, Integer>> labelMap = loadLabelMap(idMap, setup.loadWithLabels);
+        final AbstractMap.SimpleEntry<HashMap<Integer, ArrayList<LabelImporter.IdNameTuple>>, HashMap<AbstractMap.SimpleEntry<Long, Long>, Integer>> labelMap = loadLabelMap(idMap, setup.loadWithLabels);
 
 
         final Supplier<WeightMapping> relWeights = () -> newWeightMap(
@@ -125,7 +122,7 @@ public class HeavyGraphFactory extends GraphFactory {
             final Supplier<WeightMapping> relWeightsSupplier,
             final Supplier<WeightMapping> nodeWeightsSupplier,
             final Supplier<WeightMapping> nodePropsSupplier,
-            final AbstractMap.SimpleEntry<HashMap<Integer, ArrayList<Object>>, HashMap<AbstractMap.SimpleEntry<Long, Long>, Integer>> labelMap,
+            final AbstractMap.SimpleEntry<HashMap<Integer, ArrayList<LabelImporter.IdNameTuple>>, HashMap<AbstractMap.SimpleEntry<Long, Long>, Integer>> labelMap,
             Collection<RelationshipImporter> tasks) {
         if (tasks.size() == 1) {
             RelationshipImporter importer = tasks.iterator().next();

--- a/core/src/main/java/org/neo4j/graphalgo/core/heavyweight/RelationshipImporter.java
+++ b/core/src/main/java/org/neo4j/graphalgo/core/heavyweight/RelationshipImporter.java
@@ -27,6 +27,7 @@ import org.neo4j.graphalgo.api.GraphSetup;
 import org.neo4j.graphalgo.api.WeightMapping;
 import org.neo4j.graphalgo.core.GraphDimensions;
 import org.neo4j.graphalgo.core.IdMap;
+import org.neo4j.graphalgo.core.LabelImporter;
 import org.neo4j.graphalgo.core.WeightMap;
 import org.neo4j.graphalgo.core.utils.ImportProgress;
 import org.neo4j.graphalgo.core.utils.RawValues;
@@ -335,7 +336,7 @@ final class RelationshipImporter extends StatementTask<Void, EntityNotFoundExcep
         weights.put(relId, doubleValue);
     }
 
-    Graph toGraph(final IdMap idMap, final AbstractMap.SimpleEntry<HashMap<Integer, ArrayList<Object>>, HashMap<AbstractMap.SimpleEntry<Long, Long>, Integer>> labelMap) {
+    Graph toGraph(final IdMap idMap, final AbstractMap.SimpleEntry<HashMap<Integer, ArrayList<LabelImporter.IdNameTuple>>, HashMap<AbstractMap.SimpleEntry<Long, Long>, Integer>> labelMap) {
         return new HeavyGraph(
                 idMap,
                 matrix,

--- a/tests/src/test/java/org/neo4j/graphalgo/core/heavyweight/LabelMapTest.java
+++ b/tests/src/test/java/org/neo4j/graphalgo/core/heavyweight/LabelMapTest.java
@@ -3,9 +3,9 @@ package org.neo4j.graphalgo.core.heavyweight;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.neo4j.graphalgo.metaPathComputationProcs.GettingStartedProc;
 import org.neo4j.graphalgo.TestDatabaseCreator;
 import org.neo4j.graphalgo.core.GraphLoader;
+import org.neo4j.graphalgo.metaPathComputationProcs.GettingStartedProc;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.kernel.api.exceptions.KernelException;
 import org.neo4j.kernel.impl.proc.Procedures;
@@ -22,7 +22,7 @@ public class LabelMapTest {
     @BeforeClass
     public static void setup() throws KernelException {
         final String cypher =
-                "CREATE (a:SNP {name:\"a\"})\n" +
+                        "CREATE (a:SNP:TEST {name:\"a\"})\n" +
                         "CREATE (b:PHN {name:\"b\"})\n" +
                         "CREATE (c:SNP {name:\"c\"})\n" +
                         "CREATE (d:PHN {name:\"d\"})\n" +
@@ -134,7 +134,20 @@ public class LabelMapTest {
                 .withLabelAsProperty(true)
                 .load(HeavyGraphFactory.class);
 
-        assert(1 == graphWithLabelMap.getLabel(1));
+        assert(2 == graphWithLabelMap.getLabel(1));
+    }
+
+    @Test
+    public void testMultipleLabels(){
+        final HeavyGraph graphWithLabelMap;
+
+        graphWithLabelMap = (HeavyGraph) new GraphLoader(api)
+                .withLabelAsProperty(true)
+                .load(HeavyGraphFactory.class);
+
+        Integer[] expectedLabels = {0, 1};
+
+        assertEquals(expectedLabels, graphWithLabelMap.getLabels(0));
     }
 
     @Test
@@ -145,7 +158,7 @@ public class LabelMapTest {
                 .load(HeavyGraphFactory.class);
 
         Collection<Integer> allLabels = graphWithLabelMap.getAllLabels();
-        assertEquals(3, allLabels.size());
+        assertEquals(4, allLabels.size());
     }
 }
 


### PR DESCRIPTION
Allow to load and access all labels for nodes in the heavy graph. This is a "quick and dirty" implementation that simply extends the existing `LabelImporter`. This importer is really subject to be cleanly refactored and to use efficient data structures.